### PR TITLE
package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this plugin to your Cordova project.
 
     cordova plugin add https://github.com/metova/coffee-script-cordova-plugin
 
-	Since Cordova CLI 7 all the plugins need a package.json file !
+    Since Cordova CLI 7 all the plugins need a package.json file !
 	
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Add this plugin to your Cordova project.
 
     cordova plugin add https://github.com/metova/coffee-script-cordova-plugin
 
+	Since Cordova CLI 7 all the plugins need a package.json file !
+	
 ## Usage
 
 Never think about compiling your CoffeeScript again!

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Add this plugin to your Cordova project.
 
     cordova plugin add https://github.com/metova/coffee-script-cordova-plugin
 
-	Since Cordova CLI 7 all the plugins need a package.json file !
-	
 ## Usage
 
 Never think about compiling your CoffeeScript again!

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this plugin to your Cordova project.
 
     cordova plugin add https://github.com/metova/coffee-script-cordova-plugin
 
-    Since Cordova CLI 7 all the plugins need a package.json file !
+	Since Cordova CLI 7 all the plugins need a package.json file !
 	
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "coffee-script-cordova-plugin",
+  "version": "0.0.1",
+  "description": "A CoffeeScript Plugin for Cordova.",
+  "cordova": {
+    "id": "com.metova.cordova.coffeescript",
+    "platforms": []
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/metova/coffee-script-cordova-plugin.git"
+  },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Metova, Inc.",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/metova/coffee-script-cordova-plugin/issues"
+  },
+  "homepage": "https://github.com/metova/coffee-script-cordova-plugin#readme"
+}


### PR DESCRIPTION
Hello,
since Cordova CLI 7 all the plugins need a package.json file !
Without that file it is not possible to add a plugin to cordova project.

Accordign to this instruction from
(https://stackoverflow.com/questions/44095982/error-when-adding-a-cordova-plugin#44226749)
:

"You can use plugman to create the package.json easily
npm install -g plugman
plugman createpackagejson /path/to/your/plugin
It will prompt you to enter the plugin information that is not available
on the existing plugin.xml
Then you can send a PR to the plugin author so other people doesn't have
to do this."

.. i created necessary file that way.

So, please add it to the master branch as soon as possible.